### PR TITLE
Enter XML file path via command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ A simple ball balancing environment was implemented as a starting point. The obs
 
 1. The model in MJCF format is located in the [assets](https://github.com/denisgriaznov/CustomMuJoCoEnviromentForRL/tree/master/assets) folder. Place the xml file of your own model there. Configure it with the necessary joints and actuators.
 
-2. By running the [model_viewer.py](https://github.com/denisgriaznov/CustomMuJoCoEnviromentForRL/blob/master/model_viewer.py) file, you can test all actuators, as well as the physics of the model in general, in a convenient interactive mode. To do this, insert the name of your model file in this line:
+2. By running the [model_viewer.py](https://github.com/denisgriaznov/CustomMuJoCoEnviromentForRL/blob/master/model_viewer.py) file, you can test all actuators, as well as the physics of the model in general, in a convenient interactive mode. To do this, run the following command:
 
 ```
-model = mujoco.MjModel.from_xml_path("<PATH OF YOUR XML MODEL FILE>")
+python model_viewer.py --path path/towards/your/xml/file
 ```
 
 3. Create your own environment class similar to [BallBalanceEnv](https://github.com/denisgriaznov/CustomMuJoCoEnviromentForRL/blob/master/ball_balance_env.py). 

--- a/model_viewer.py
+++ b/model_viewer.py
@@ -1,18 +1,35 @@
 import time
 import mujoco.viewer
+import argparse
 
-model = mujoco.MjModel.from_xml_path("assets/ball_balance.xml")
-data = mujoco.MjData(model)
-n_steps = 5
+def create_parser():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--path",
+        type = str,
+        help = "Path towards your xml file",
+        required = True
+    )
+    
+    return parser
 
-# viewer shows frame of environment every n_steps
-with mujoco.viewer.launch_passive(model, data) as viewer:
-    start = time.time()
-    while True:
-        step_start = time.time()
-        for _ in range(n_steps):
-            mujoco.mj_step(model, data)
-        viewer.sync()
-        time_until_next_step = model.opt.timestep - (time.time() - step_start)
-        if time_until_next_step > 0:
-            time.sleep(time_until_next_step)
+if __name__ == "__main__":
+    parser = create_parser()
+    args = parser.parse_args()
+    xml_path = args.path
+
+    model = mujoco.MjModel.from_xml_path(xml_path)
+    data = mujoco.MjData(model)
+    n_steps = 5
+
+    # viewer shows frame of environment every n_steps
+    with mujoco.viewer.launch_passive(model, data) as viewer:
+        start = time.time()
+        while True:
+            step_start = time.time()
+            for _ in range(n_steps):
+                mujoco.mj_step(model, data)
+            viewer.sync()
+            time_until_next_step = model.opt.timestep - (time.time() - step_start)
+            if time_until_next_step > 0:
+                time.sleep(time_until_next_step)


### PR DESCRIPTION
I modified `model_viewer.py` a bit such that user won't need to modify the python code directly in order to enter their XML file path. Now, they could simply use the command line to specify the path.

i.e.
```
python model_viewer.py --path env/my_env.xml
```